### PR TITLE
Workflow for building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,12 +17,12 @@ jobs:
           - '7.4.0'
           - '7.3.12'
           - '7.2.25'
-        flavour:
+        target:
           - 'cli'
           - 'fpm'
 
         # Manually exclude the miss-matching versions from the build matrix.
-        # I really wish there was a better way to set this up.
+        # Waiting for anchoring support so the duplication can be removed.
         exclude:
           - { minor: '7.4', patch: '7.3.12' }
           - { minor: '7.4', patch: '7.2.25' }
@@ -31,29 +31,230 @@ jobs:
           - { minor: '7.2', patch: '7.4.0' }
           - { minor: '7.2', patch: '7.3.12' }
 
-    # Make sure the patch belongs to the minor.
-    # A safety net assuming the above matrix exclude doesn't work.
     # This would work but matrix doesn't work here, its evaluated before the matrix is expanded.
     # https://github.community/t5/GitHub-Actions/Matrix-cannot-be-used-in-jobs-level-if/td-p/41048
-#    if: startsWith(matrix.patch, matrix.minor)
+    # if: startsWith(matrix.patch, matrix.minor)
 
     env:
-      TAG_MINOR: 'musurp/php:${{ matrix.minor }}-${{ matrix.flavour }}'
-      TAG_PATCH: 'musurp/php:${{ matrix.patch }}-${{ matrix.flavour }}'
+      TAG_MINOR: 'musurp/php:${{ matrix.minor }}-${{ matrix.target }}'
+      TAG_PATCH: 'musurp/php:${{ matrix.patch }}-${{ matrix.target }}'
 
     steps:
       - uses: actions/checkout@master
 
-      - name: Build & Tag
-        run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.flavour }}"
+      - name: 'Build & Tag'
+        run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.target }}"
 
       - name: 'Smoke Test: CLI'
         run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
-        if: matrix.flavour == 'cli'
+        if: matrix.target == 'cli'
 
       - name: 'Smoke Test: FPM'
         run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
-        if: matrix.flavour == 'fpm'
+        if: matrix.target == 'fpm'
+
+      # Only done for master branch.
+      # Publish the image to docker hub.
+
+      - name: 'Publish: Authenticate'
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Patch Version'
+        run: docker push "$TAG_PATCH"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Minor Version'
+        run: docker push "$TAG_MINOR"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Logout'
+        run: docker logout
+        if: github.ref == 'refs/heads/master'
+
+  build-xdebug-images:
+    runs-on: ubuntu-latest
+
+    needs:
+      - build-base-images
+
+    strategy:
+      matrix:
+        minor:
+          - '7.4'
+          - '7.3'
+          - '7.2'
+        patch:
+          - '7.4.0'
+          - '7.3.12'
+          - '7.2.25'
+        target:
+          - 'cli'
+          - 'fpm'
+
+        # Manually exclude the miss-matching versions from the build matrix.
+        # Waiting for anchoring support so the duplication can be removed.
+        exclude:
+          - { minor: '7.4', patch: '7.3.12' }
+          - { minor: '7.4', patch: '7.2.25' }
+          - { minor: '7.3', patch: '7.4.0' }
+          - { minor: '7.3', patch: '7.2.25' }
+          - { minor: '7.2', patch: '7.4.0' }
+          - { minor: '7.2', patch: '7.3.12' }
+
+    env:
+      TAG_MINOR: 'musurp/php-dev:${{ matrix.minor }}-${{ matrix.target }}'
+      TAG_PATCH: 'musurp/php-dev:${{ matrix.patch }}-${{ matrix.target }}'
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: 'Build & Tag'
+        run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.target }}/xdebug"
+
+      - name: 'Smoke Test: CLI'
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
+        if: matrix.target == 'cli'
+
+      - name: 'Smoke Test: FPM'
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
+        if: matrix.target == 'fpm'
+
+      # Only done for master branch.
+      # Publish the image to docker hub.
+
+      - name: 'Publish: Authenticate'
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Patch Version'
+        run: docker push "$TAG_PATCH"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Minor Version'
+        run: docker push "$TAG_MINOR"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Logout'
+        run: docker logout
+        if: github.ref == 'refs/heads/master'
+
+  build-flavour-images:
+    runs-on: ubuntu-latest
+
+    needs:
+      - build-xdebug-images
+
+    strategy:
+      matrix:
+        minor:
+          - '7.4'
+          - '7.3'
+          - '7.2'
+        patch:
+          - '7.4.0'
+          - '7.3.12'
+          - '7.2.25'
+        target:
+          - 'cli'
+        flavour:
+          - 'supervisor'
+
+        # Manually exclude the miss-matching versions from the build matrix.
+        # Waiting for anchoring support so the duplication can be removed.
+        exclude:
+          - { minor: '7.4', patch: '7.3.12' }
+          - { minor: '7.4', patch: '7.2.25' }
+          - { minor: '7.3', patch: '7.4.0' }
+          - { minor: '7.3', patch: '7.2.25' }
+          - { minor: '7.2', patch: '7.4.0' }
+          - { minor: '7.2', patch: '7.3.12' }
+
+    env:
+      TAG_MINOR: 'musurp/php:${{ matrix.minor }}-${{ matrix.target }}-${{ matrix.flavour }}'
+      TAG_PATCH: 'musurp/php:${{ matrix.patch }}-${{ matrix.target }}-${{ matrix.flavour }}'
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: 'Build & Tag'
+        run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.target }}/${{ matrix.flavour }}"
+
+      - name: 'Smoke Test: CLI'
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
+        if: matrix.target == 'cli'
+
+      - name: 'Smoke Test: FPM'
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
+        if: matrix.target == 'fpm'
+
+      # Only done for master branch.
+      # Publish the image to docker hub.
+
+      - name: 'Publish: Authenticate'
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Patch Version'
+        run: docker push "$TAG_PATCH"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Minor Version'
+        run: docker push "$TAG_MINOR"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Logout'
+        run: docker logout
+        if: github.ref == 'refs/heads/master'
+
+  build-flavour-xdebug-images:
+    runs-on: ubuntu-latest
+
+    needs:
+      - build-flavour-images
+
+    strategy:
+      matrix:
+        minor:
+          - '7.4'
+          - '7.3'
+          - '7.2'
+        patch:
+          - '7.4.0'
+          - '7.3.12'
+          - '7.2.25'
+        target:
+          - 'cli'
+        flavour:
+          - 'supervisor'
+
+        # Manually exclude the miss-matching versions from the build matrix.
+        # Waiting for anchoring support so the duplication can be removed.
+        exclude:
+          - { minor: '7.4', patch: '7.3.12' }
+          - { minor: '7.4', patch: '7.2.25' }
+          - { minor: '7.3', patch: '7.4.0' }
+          - { minor: '7.3', patch: '7.2.25' }
+          - { minor: '7.2', patch: '7.4.0' }
+          - { minor: '7.2', patch: '7.3.12' }
+
+    env:
+      TAG_MINOR: 'musurp/php-dev:${{ matrix.minor }}-${{ matrix.target }}-${{ matrix.flavour }}'
+      TAG_PATCH: 'musurp/php-dev:${{ matrix.patch }}-${{ matrix.target }}-${{ matrix.flavour }}'
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: 'Build & Tag'
+        run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.target }}/xdebug/${{ matrix.flavour }}"
+
+      - name: 'Smoke Test: CLI'
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
+        if: matrix.target == 'cli'
+
+      - name: 'Smoke Test: FPM'
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
+        if: matrix.target == 'fpm'
 
       # Only done for master branch.
       # Publish the image to docker hub.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,62 @@
+name: PHP Images
+
+on:
+  - push
+
+jobs:
+  build-base-images:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        minor:
+          - '7.4'
+          - '7.3'
+          - '7.2'
+        patch:
+          - '7.4.0'
+          - '7.3.12'
+          - '7.2.25'
+        flavour:
+          - 'cli'
+          - 'fpm'
+
+    # Make sure we are only dealing with combinations of the same minor and patch versions.
+    if: startsWith(matrix.patch, matrix.minor)
+
+    env:
+      TAG_MINOR: 'musurp/php:${{ matrix.minor }}-${{ matrix.flavour }}'
+      TAG_PATCH: 'musurp/php:${{ matrix.patch }}-${{ matrix.flavour }}'
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Build & Tag
+        run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.flavour }}"
+
+      - name: 'Smoke Test: CLI'
+        run: docker run -it "$TAG_MINOR" sh -c "php -v"
+        if: matrix.flavour == 'cli'
+
+      - name: 'Smoke Test: FPM'
+        run: docker run -it "$TAG_MINOR" sh -c "php-fpm -v"
+        if: matrix.flavour == 'fpm'
+
+      # Only done for master branch.
+      # Publish the image to docker hub.
+
+      - name: 'Publish: Authenticate'
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Patch Version'
+        run: docker push "$TAG_PATCH"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Minor Version'
+        run: docker push "$TAG_MINOR"
+        if: github.ref == 'refs/heads/master'
+
+      - name: 'Publish: Logout'
+        run: docker logout
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,11 +48,11 @@ jobs:
         run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.flavour }}"
 
       - name: 'Smoke Test: CLI'
-        run: docker run -it --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
         if: matrix.flavour == 'cli'
 
       - name: 'Smoke Test: FPM'
-        run: docker run -it --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
+        run: docker run --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
         if: matrix.flavour == 'fpm'
 
       # Only done for master branch.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,21 @@ jobs:
           - 'cli'
           - 'fpm'
 
-    # Make sure we are only dealing with combinations of the same minor and patch versions.
-    if: startsWith(matrix.patch, matrix.minor)
+        # Manually exclude the miss-matching versions from the build matrix.
+        # I really wish there was a better way to set this up.
+        exclude:
+          - { minor: '7.4', patch: '7.3.12' }
+          - { minor: '7.4', patch: '7.2.25' }
+          - { minor: '7.3', patch: '7.4.0' }
+          - { minor: '7.3', patch: '7.2.25' }
+          - { minor: '7.2', patch: '7.4.0' }
+          - { minor: '7.2', patch: '7.3.12' }
+
+    # Make sure the patch belongs to the minor.
+    # A safety net assuming the above matrix exclude doesn't work.
+    # This would work but matrix doesn't work here, its evaluated before the matrix is expanded.
+    # https://github.community/t5/GitHub-Actions/Matrix-cannot-be-used-in-jobs-level-if/td-p/41048
+#    if: startsWith(matrix.patch, matrix.minor)
 
     env:
       TAG_MINOR: 'musurp/php:${{ matrix.minor }}-${{ matrix.flavour }}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,11 +48,11 @@ jobs:
         run: docker build --compress --tag="$TAG_MINOR" --tag="$TAG_PATCH" "php/${{ matrix.minor }}/${{ matrix.flavour }}"
 
       - name: 'Smoke Test: CLI'
-        run: docker run -it "$TAG_MINOR" sh -c "php -v"
+        run: docker run -it --entrypoint "/bin/sh" "$TAG_MINOR" -c "php -v"
         if: matrix.flavour == 'cli'
 
       - name: 'Smoke Test: FPM'
-        run: docker run -it "$TAG_MINOR" sh -c "php-fpm -v"
+        run: docker run -it --entrypoint "/bin/sh" "$TAG_MINOR" -c "php-fpm -v"
         if: matrix.flavour == 'fpm'
 
       # Only done for master branch.


### PR DESCRIPTION
Makes use of Github actions to build a matrix of versions, debug and flavour images for PHP. Will run on every push (for now) but will only publish when the push is in the master branch.